### PR TITLE
Change gem name on setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,13 +19,13 @@ First of all we need to require the right file for the project. There are curren
 ### Rails  
 
 ```ruby
-gem "sapience-rb", require: "sapience/rails"
+gem "sapience", require: "sapience/rails"
 ```
 
 ### Grape 
 
 ```ruby
-gem "sapience-rb", require: "sapience/grape"
+gem "sapience", require: "sapience/grape"
 ```
 
 In your Base API class


### PR DESCRIPTION
As specified in [sapience.gemspec file](https://github.com/reevoo/sapience-rb/blob/master/sapience.gemspec#L7) the name of the gem is sapience and not sapience-rb. I have tried to add it to a project today and it failed with ```Could not find gem 'sapience-rb'...```