### PR TITLE
Filter out sensitive informations from the logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+- Added `filter_parameters` configuration to obfuscate sensitive information such as passwords for rack-like applications
+
 ## v1.0.8
 
 - Delayed configuration of Sentry until the configuration is valid
@@ -34,11 +36,11 @@
 
 ## v0.2.13
 
-- Set Rails.logger even some gems disables logging on initialisation. 
+- Set Rails.logger even some gems disables logging on initialisation.
 
 ## v0.2.12
 
-- Adds support for Rails apps with disabled ActiveRecord 
+- Adds support for Rails apps with disabled ActiveRecord
 
 ## v0.2.11
 
@@ -77,7 +79,7 @@
 
 ## v0.2.0
 
-- Rename Appender::File to Appender::Stream. Accept option stream instead of file in `sapience.yml`  
+- Rename Appender::File to Appender::Stream. Accept option stream instead of file in `sapience.yml`
 
 ## v0.1.12
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -1,5 +1,8 @@
 ---
 default:
+  filter_parameters:
+    - password
+    - password_confirmation
   log_executor: single_thread_executor
   log_level: info
   appenders:

--- a/lib/sapience/configuration.rb
+++ b/lib/sapience/configuration.rb
@@ -8,15 +8,16 @@ module Sapience
   class Configuration
     attr_reader :default_level, :backtrace_level, :backtrace_level_index
     attr_writer :host
-    attr_accessor :app_name, :ap_options, :appenders, :log_executor
+    attr_accessor :app_name, :ap_options, :appenders, :log_executor, :filter_parameters
 
     SUPPORTED_EXECUTORS = %i(single_thread_executor immediate_executor).freeze
     DEFAULT = {
-      log_level:   :info,
-      host:        nil,
-      ap_options:  { multiline: false },
-      appenders:   [{ stream: { io: STDOUT, formatter: :color } }],
-      log_executor: :single_thread_executor,
+      log_level:         :info,
+      host:              nil,
+      ap_options:        { multiline: false },
+      appenders:         [{ stream: { io: STDOUT, formatter: :color } }],
+      log_executor:      :single_thread_executor,
+      filter_parameters: %w(password password_confirmation),
     }.freeze
 
     # Initial default Level for all new instances of Sapience::Logger
@@ -25,13 +26,14 @@ module Sapience
       @options             = DEFAULT.merge(options.dup.deep_symbolize_keyz!)
       @options[:log_executor] &&= @options[:log_executor].to_sym
       validate_log_executor!(@options[:log_executor])
-      self.default_level   = @options[:log_level].to_sym
-      self.backtrace_level = @options[:log_level].to_sym
-      self.host            = @options[:host]
-      self.app_name        = @options[:app_name]
-      self.ap_options      = @options[:ap_options]
-      self.appenders       = @options[:appenders]
-      self.log_executor    = @options[:log_executor]
+      self.default_level     = @options[:log_level].to_sym
+      self.backtrace_level   = @options[:log_level].to_sym
+      self.host              = @options[:host]
+      self.app_name          = @options[:app_name]
+      self.ap_options        = @options[:ap_options]
+      self.appenders         = @options[:appenders]
+      self.log_executor      = @options[:log_executor]
+      self.filter_parameters = @options[:filter_parameters]
     end
 
     # Sets the global default log level

--- a/lib/sapience/sapience.rb
+++ b/lib/sapience/sapience.rb
@@ -6,12 +6,13 @@ require "English"
 # Example:
 #
 # Sapience.configure do |config|
-#   config.default_level   = ENV.fetch('SAPIENCE_DEFAULT_LEVEL') { :info }.to_sym
-#   config.backtrace_level = ENV.fetch('SAPIENCE_BACKTRACE_LEVEL') { :info }.to_sym
-#   config.app_name        = 'TestApplication'
-#   config.host            = ENV.fetch('SAPIENCE_HOST', nil)
-#   config.ap_options      = { multiline: false }
-#   config.appenders       = [
+#   config.default_level     = ENV.fetch('SAPIENCE_DEFAULT_LEVEL') { :info }.to_sym
+#   config.backtrace_level   = ENV.fetch('SAPIENCE_BACKTRACE_LEVEL') { :info }.to_sym
+#   config.app_name          = 'TestApplication'
+#   config.host              = ENV.fetch('SAPIENCE_HOST', nil)
+#   config.ap_options        = { multiline: false }
+#   config.filter_parameters << "credit_card"
+#   config.appenders         = [
 #     { stream: { io: STDOUT, formatter: :color } },
 #     { statsd: { url: 'udp://localhost:2222' } },
 #     { sentry: { dsn: 'https://foobar:443' } },

--- a/spec/lib/sapience/config_loader_spec.rb
+++ b/spec/lib/sapience/config_loader_spec.rb
@@ -15,6 +15,7 @@ describe Sapience::ConfigLoader do
           expect(load_from_file).to eq(
           "default"    => {
             "log_executor" => "single_thread_executor",
+            "filter_parameters" => %w(password password_confirmation),
             "log_level" => "info",
             "appenders" => [{
               "stream" => {
@@ -80,6 +81,7 @@ describe Sapience::ConfigLoader do
           expect(load_from_file).to eq(
             "default" => {
               "log_executor" => "single_thread_executor",
+              "filter_parameters" => %w(password password_confirmation),
               "log_level" => "info",
               "appenders" => [
                 {

--- a/spec/lib/sapience/log_spec.rb
+++ b/spec/lib/sapience/log_spec.rb
@@ -207,6 +207,42 @@ describe Sapience::Log do
       its(:to_h) do
         is_expected.to match(expected)
       end
+
+      context "when payload contains sensitive information" do
+        let(:payload) do
+          {
+            params: {
+              "password" => "some_password",
+              "password_confirmation" => "some_password",
+              "foo" => "bar",
+            },
+          }
+        end
+
+        it "replaces the value of default fields to [FILTERED]" do
+          expect(subject.to_h[:params]).to eq(
+            "password" => "[FILTERED]",
+            "password_confirmation" => "[FILTERED]",
+            "foo" => "bar",
+          )
+        end
+
+        context "with configuration" do
+          describe "overriding configuration" do
+            before(:each) do
+              allow(Sapience.config).to receive(:filter_parameters).and_return(["foo"])
+            end
+
+            it "filters overridden fields" do
+              expect(subject.to_h[:params]).to eq(
+                "password" => "some_password",
+                "password_confirmation" => "some_password",
+                "foo" => "[FILTERED]",
+              )
+            end
+          end
+        end
+      end
     end
 
     context "when payload is a String" do


### PR DESCRIPTION
This PR replaces sensitive informations (like password, credit_card, etc) with ```[FILTERED]```
By default the sensitive fields are ```password``` and ```password_confirmation ``` but more fields can be added using sensitive_fields configuration.

This fixes https://github.com/reevoo/sapience-rb/issues/4