### PR TITLE
Fix a problem logging messages to sentry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v1.0.13
+
+- Fix a problem with logging extra parameters to sentry
+
 ## v1.0.12
 
 - Fix NoMethodError in Grape::Notification

--- a/lib/sapience/appender/sentry.rb
+++ b/lib/sapience/appender/sentry.rb
@@ -68,7 +68,7 @@ module Sapience
           message = {
             error_class:   context.delete(:name),
             error_message: context.delete(:message),
-            context: context,
+            extra: context,
           }
           message[:backtrace] = log.backtrace if log.backtrace
           Raven.capture_message(message[:error_message], message)

--- a/spec/lib/sapience/appender/sentry_spec.rb
+++ b/spec/lib/sapience/appender/sentry_spec.rb
@@ -64,7 +64,7 @@ describe Sapience::Appender::Sentry do
           a_hash_including(
             error_class: "Sapience::Appender::Sentry",
             error_message: "AppenderRavenTest log message",
-            context: {
+            extra: {
               pid: a_kind_of(Integer),
               thread: a_kind_of(String),
               time: a_kind_of(Time),
@@ -113,7 +113,7 @@ describe Sapience::Appender::Sentry do
           a_hash_including(
             error_class: "Sapience::Appender::Sentry",
             error_message: "AppenderRavenTest log message",
-            context: {
+            extra: {
               pid: a_kind_of(Integer),
               thread: a_kind_of(String),
               time: a_kind_of(Time),


### PR DESCRIPTION
According to https://docs.sentry.io/clients/ruby/context/ it should be named `:extra`.