### PR TITLE
Set the default level for ActiveRecord to info

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ The `app_name` is required to be configured. Sapience will fail on startup if ap
 ```ruby
 Sapience.configure do |config|
   config.default_level   = :info
+  config.log_level_active_record = :debug
   config.backtrace_level = :error
   config.appenders       = [
     { stream: { io: STDOUT, formatter: :color } },
@@ -91,6 +92,7 @@ test:
 
 development:
   log_executor: single_thread_executor
+  log_level_active_record: debug
   log_level: debug
   appenders:
     - stream:

--- a/lib/sapience/configuration.rb
+++ b/lib/sapience/configuration.rb
@@ -4,13 +4,14 @@ module Sapience
 
   # rubocop:disable ClassVars
   class Configuration
-    attr_reader :default_level, :backtrace_level, :backtrace_level_index
+    attr_reader :default_level, :log_level_active_record, :backtrace_level, :backtrace_level_index
     attr_writer :host
     attr_accessor :app_name, :ap_options, :appenders, :log_executor, :filter_parameters, :metrics, :error_handler
 
     SUPPORTED_EXECUTORS = %i(single_thread_executor immediate_executor).freeze
     DEFAULT = {
-      log_level:         :info,
+      log_level:               :info,
+      log_level_active_record: :info,
       host:              nil,
       ap_options:        { multiline: false },
       appenders:         [{ stream: { io: STDOUT, formatter: :color } }],
@@ -26,7 +27,8 @@ module Sapience
       @options             = DEFAULT.merge(options.dup.deep_symbolize_keyz!)
       @options[:log_executor] &&= @options[:log_executor].to_sym
       validate_log_executor!(@options[:log_executor])
-      self.default_level     = @options[:log_level].to_sym
+      self.default_level           = @options[:log_level].to_sym
+      self.log_level_active_record = @options[:log_level_active_record].to_sym
       self.backtrace_level   = @options[:log_level].to_sym
       self.host              = @options[:host]
       self.app_name          = @options[:app_name]
@@ -43,6 +45,13 @@ module Sapience
       @default_level       = level
       # For performance reasons pre-calculate the level index
       @default_level_index = level_to_index(level)
+    end
+
+    # Sets the active record log level
+    def log_level_active_record=(level)
+      @log_level_active_record = level
+      # For performance reasons pre-calculate the level index
+      @log_level_active_record_index = level_to_index(level)
     end
 
     # Returns the symbolic level for the supplied level index

--- a/lib/sapience/rails/engine.rb
+++ b/lib/sapience/rails/engine.rb
@@ -74,7 +74,8 @@ module Sapience
         # Sapience::Extensions::ActiveSupport::MailerLogSubscriber.attach_to :action_mailer
         if defined?(ActiveRecord)
           Sapience::Extensions::ActiveRecord::Notifications.use
-          ActiveRecord::Base.logger.level = Sapience.config.log_level_active_record
+          ActiveRecord::Base.logger.level =
+              Sapience.config.log_level_active_record if defined?(ActiveRecord::Base.logger.level)
         end
 
         Sapience::Extensions::ActionView::LogSubscriber.attach_to :action_view

--- a/lib/sapience/rails/engine.rb
+++ b/lib/sapience/rails/engine.rb
@@ -73,8 +73,8 @@ module Sapience
         Sapience::Extensions::ActionController::LogSubscriber.attach_to :action_controller
         # Sapience::Extensions::ActiveSupport::MailerLogSubscriber.attach_to :action_mailer
         if defined?(ActiveRecord)
-          Sapience::Extensions::ActiveRecord::LogSubscriber.attach_to :active_record
           Sapience::Extensions::ActiveRecord::Notifications.use
+          ActiveRecord::Base.logger.level = Sapience.config.log_level_active_record
         end
 
         Sapience::Extensions::ActionView::LogSubscriber.attach_to :action_view

--- a/spec/lib/sapience/configuration_spec.rb
+++ b/spec/lib/sapience/configuration_spec.rb
@@ -9,6 +9,17 @@ describe Sapience::Configuration do
     end
   end
 
+  describe "#log_level_active_record" do
+    it "sets the default level to :info" do
+      expect(Sapience.config.log_level_active_record).to eq(:info)
+    end
+
+    it "can override the default level" do
+      Sapience.config.log_level_active_record = :debug
+      expect(Sapience.config.log_level_active_record).to eq(:debug)
+    end
+  end
+
   describe "#level_to_index" do
     def level_to_index
       subject.level_to_index(level)

--- a/test_apps/grape/gemfiles/grape_0.16.2.gemfile.lock
+++ b/test_apps/grape/gemfiles/grape_0.16.2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../../..
   specs:
-    sapience (2.0.1)
+    sapience (2.0.2)
       concurrent-ruby (~> 1.0)
 
 GEM
@@ -21,20 +21,20 @@ GEM
       descendants_tracker (~> 0.0.4)
       ice_nine (~> 0.11.0)
       thread_safe (~> 0.3, >= 0.3.1)
-    builder (3.2.2)
+    builder (3.2.3)
     byebug (9.0.6)
     coderay (1.1.1)
     coercible (1.0.0)
       descendants_tracker (~> 0.0.1)
-    concurrent-ruby (1.0.2)
+    concurrent-ruby (1.0.4)
     descendants_tracker (0.0.4)
       thread_safe (~> 0.3, >= 0.3.1)
-    diff-lcs (1.2.5)
+    diff-lcs (1.3)
     docile (1.1.5)
-    dogstatsd-ruby (2.1.0)
+    dogstatsd-ruby (2.2.0)
     enumerable-lazy (0.0.2)
     equalizer (0.0.11)
-    faraday (0.9.2)
+    faraday (0.11.0)
       multipart-post (>= 1.2, < 3)
     fuubar (2.2.0)
       rspec-core (~> 3.0)
@@ -49,14 +49,14 @@ GEM
       rack (>= 1.3.0)
       rack-accept
       virtus (>= 1.0.0)
-    hashie (3.4.6)
-    i18n (0.7.0)
+    hashie (3.5.3)
+    i18n (0.8.0)
     ice_nine (0.11.2)
-    json (1.8.3)
+    json (1.8.6)
     method_source (0.8.2)
-    minitest (5.9.1)
+    minitest (5.10.1)
     multi_json (1.12.1)
-    multi_xml (0.5.5)
+    multi_xml (0.6.0)
     multipart-post (2.0.0)
     mustermann19 (0.4.4)
       enumerable-lazy
@@ -64,10 +64,10 @@ GEM
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
       slop (~> 3.4)
-    pry-byebug (3.4.0)
+    pry-byebug (3.4.2)
       byebug (~> 9.0)
       pry (~> 0.10)
-    puma (3.6.0)
+    puma (3.7.0)
     rack (1.6.4)
     rack-accept (0.4.5)
       rack (>= 0.4)
@@ -76,7 +76,7 @@ GEM
     racksh (1.0.0)
       rack (>= 1.0)
       rack-test (>= 0.5)
-    rake (11.3.0)
+    rake (12.0.0)
     rspec (3.5.0)
       rspec-core (~> 3.5.0)
       rspec-expectations (~> 3.5.0)
@@ -94,9 +94,9 @@ GEM
       rspec-support (~> 3.5.0)
     rspec-support (3.5.0)
     ruby-progressbar (1.8.1)
-    sentry-raven (2.1.2)
-      faraday (>= 0.7.6, < 0.10.x)
-    simplecov (0.12.0)
+    sentry-raven (2.3.0)
+      faraday (>= 0.7.6, < 1.0)
+    simplecov (0.13.0)
       docile (~> 1.1.0)
       json (>= 1.8, < 3)
       simplecov-html (~> 0.10.0)
@@ -105,7 +105,7 @@ GEM
       json
       simplecov
     slop (3.6.0)
-    thor (0.19.1)
+    thor (0.19.4)
     thread_safe (0.3.5)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
@@ -137,4 +137,4 @@ DEPENDENCIES
   simplecov-json
 
 BUNDLED WITH
-   1.13.2
+   1.13.6

--- a/test_apps/grape/gemfiles/grape_0.17.0.gemfile.lock
+++ b/test_apps/grape/gemfiles/grape_0.17.0.gemfile.lock
@@ -1,13 +1,13 @@
 PATH
   remote: ../../..
   specs:
-    sapience (2.0.1)
+    sapience (2.0.2)
       concurrent-ruby (~> 1.0)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (5.0.0.1)
+    activesupport (5.0.1)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (~> 0.7)
       minitest (~> 5.1)
@@ -20,20 +20,20 @@ GEM
       descendants_tracker (~> 0.0.4)
       ice_nine (~> 0.11.0)
       thread_safe (~> 0.3, >= 0.3.1)
-    builder (3.2.2)
+    builder (3.2.3)
     byebug (9.0.6)
     coderay (1.1.1)
     coercible (1.0.0)
       descendants_tracker (~> 0.0.1)
-    concurrent-ruby (1.0.2)
+    concurrent-ruby (1.0.4)
     descendants_tracker (0.0.4)
       thread_safe (~> 0.3, >= 0.3.1)
-    diff-lcs (1.2.5)
+    diff-lcs (1.3)
     docile (1.1.5)
-    dogstatsd-ruby (2.1.0)
+    dogstatsd-ruby (2.2.0)
     enumerable-lazy (0.0.2)
     equalizer (0.0.11)
-    faraday (0.9.2)
+    faraday (0.11.0)
       multipart-post (>= 1.2, < 3)
     fuubar (2.2.0)
       rspec-core (~> 3.0)
@@ -48,14 +48,14 @@ GEM
       rack (>= 1.3.0)
       rack-accept
       virtus (>= 1.0.0)
-    hashie (3.4.6)
-    i18n (0.7.0)
+    hashie (3.5.3)
+    i18n (0.8.0)
     ice_nine (0.11.2)
-    json (2.0.2)
+    json (2.0.3)
     method_source (0.8.2)
-    minitest (5.9.1)
+    minitest (5.10.1)
     multi_json (1.12.1)
-    multi_xml (0.5.5)
+    multi_xml (0.6.0)
     multipart-post (2.0.0)
     mustermann19 (0.4.4)
       enumerable-lazy
@@ -63,10 +63,10 @@ GEM
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
       slop (~> 3.4)
-    pry-byebug (3.4.0)
+    pry-byebug (3.4.2)
       byebug (~> 9.0)
       pry (~> 0.10)
-    puma (3.6.0)
+    puma (3.7.0)
     rack (2.0.1)
     rack-accept (0.4.5)
       rack (>= 0.4)
@@ -75,7 +75,7 @@ GEM
     racksh (1.0.0)
       rack (>= 1.0)
       rack-test (>= 0.5)
-    rake (11.3.0)
+    rake (12.0.0)
     rspec (3.5.0)
       rspec-core (~> 3.5.0)
       rspec-expectations (~> 3.5.0)
@@ -93,9 +93,9 @@ GEM
       rspec-support (~> 3.5.0)
     rspec-support (3.5.0)
     ruby-progressbar (1.8.1)
-    sentry-raven (2.1.2)
-      faraday (>= 0.7.6, < 0.10.x)
-    simplecov (0.12.0)
+    sentry-raven (2.3.0)
+      faraday (>= 0.7.6, < 1.0)
+    simplecov (0.13.0)
       docile (~> 1.1.0)
       json (>= 1.8, < 3)
       simplecov-html (~> 0.10.0)
@@ -104,7 +104,7 @@ GEM
       json
       simplecov
     slop (3.6.0)
-    thor (0.19.1)
+    thor (0.19.4)
     thread_safe (0.3.5)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
@@ -135,4 +135,4 @@ DEPENDENCIES
   simplecov-json
 
 BUNDLED WITH
-   1.13.2
+   1.13.6


### PR DESCRIPTION
Applications can override it by seeting it by setting “log_level_active_record” property in sapience.yml file.