### PR TITLE
Load Sapience::Extensions::Notifications only for rails/grape extensions

### DIFF
--- a/lib/sapience.rb
+++ b/lib/sapience.rb
@@ -9,7 +9,6 @@ require "sapience/appender"
 require "sapience/metrics"
 require "sapience/error_handler"
 require "sapience/sapience"
-require "sapience/extensions/notifications"
 
 # @formatter:off
 

--- a/lib/sapience/grape.rb
+++ b/lib/sapience/grape.rb
@@ -1,4 +1,5 @@
 require "sapience"
+require "sapience/extensions/notifications"
 require "sapience/extensions/grape/timings"
 require "sapience/extensions/grape/middleware/logging"
 require "sapience/extensions/grape/notifications"

--- a/lib/sapience/rails/engine.rb
+++ b/lib/sapience/rails/engine.rb
@@ -1,4 +1,5 @@
 require "sapience"
+require "sapience/extensions/notifications"
 require "sapience/extensions/action_controller/live" if defined?(ActionController::Live)
 require "sapience/extensions/action_controller/log_subscriber"
 require "sapience/extensions/action_controller/notifications"


### PR DESCRIPTION
`Sapience::Extensions::Notifications` is used only when integrating with rails or grape. The class should not be loaded when the lib is used standalone.

This PR moves the loading of `Sapience::Extensions::Notifications` to the entry points for rails and grape integrations.