### PR TITLE
Ensure ErrorHandler::Silent implements the API for error handlers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## v2.2.0
+
+- Add `Sapience::ErrorHandler::Silent#capture`
+- Add `Sapience::ErrorHandler::Silent#capture!`
+- Add `Sapience::ErrorHandler::Silent#user_context`
+- Add `Sapience::ErrorHandler::Silent#tags_context`
+
 ## v2.1.0
 
 - Add `Sapience::ErrorHandler:Sentry#capture`

--- a/lib/sapience/error_handler/silent.rb
+++ b/lib/sapience/error_handler/silent.rb
@@ -20,6 +20,19 @@ module Sapience
       def capture_message(_message, _payload = {})
         nil
       end
+
+      def capture(_options: {})
+        nil
+      end
+      alias_method :capture!, :capture
+
+      def user_context(_options = {})
+        nil
+      end
+
+      def tags_context(_options = {})
+        nil
+      end
     end
   end
 end

--- a/lib/sapience/version.rb
+++ b/lib/sapience/version.rb
@@ -1,3 +1,3 @@
 module Sapience
-  VERSION = "2.1.0"
+  VERSION = "2.2.0"
 end

--- a/spec/lib/sapience/error_handler/sentry_spec.rb
+++ b/spec/lib/sapience/error_handler/sentry_spec.rb
@@ -1,4 +1,5 @@
 require "spec_helper"
+require "shared_examples_for_error_handlers"
 
 describe Sapience::ErrorHandler::Sentry do
   subject { described_class.new(init_options) }
@@ -13,6 +14,8 @@ describe Sapience::ErrorHandler::Sentry do
       dsn:   dsn,
     }
   end
+
+  it_behaves_like "error handler"
 
   describe "configuration" do
     context "when options is a valid hash" do

--- a/spec/lib/sapience/error_handler/silent_spec.rb
+++ b/spec/lib/sapience/error_handler/silent_spec.rb
@@ -1,0 +1,8 @@
+require "spec_helper"
+require "shared_examples_for_error_handlers"
+
+describe Sapience::ErrorHandler::Silent do
+  subject { described_class.new }
+
+  it_behaves_like "error handler"
+end

--- a/spec/shared_examples_for_error_handlers.rb
+++ b/spec/shared_examples_for_error_handlers.rb
@@ -1,0 +1,7 @@
+RSpec.shared_examples "error handler" do
+  %w(capture_exception capture capture! capture_message user_context tags_context).each do |m|
+    it "responds to #{m}" do
+      expect(subject).to respond_to(m.to_sym)
+    end
+  end
+end


### PR DESCRIPTION
All error handlers should implement a common API. This commit ensures that the current implementations conform to a common API spec.