### PR TITLE
[+AM] Log internal errors to $stderr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v2.2.1
+
+- Log directly to STDOUT for internal errors
+
 ## v2.2.0
 
 - Add `Sapience::ErrorHandler::Silent#capture`

--- a/lib/sapience/logger.rb
+++ b/lib/sapience/logger.rb
@@ -138,7 +138,7 @@ module Sapience
           begin
             appender.log(log)
           rescue StandardError => exc
-            self.class.logger.error "Appender thread: Failed to log to appender: #{appender.inspect}", exc
+            $stderr.write("Appender thread: Failed to log to appender: #{appender.inspect}\n #{exc.inspect}")
           end
         end
       end if @@appender_thread

--- a/lib/sapience/version.rb
+++ b/lib/sapience/version.rb
@@ -1,3 +1,3 @@
 module Sapience
-  VERSION = "2.2.0"
+  VERSION = "2.2.1"
 end

--- a/spec/lib/sapience/logger_spec.rb
+++ b/spec/lib/sapience/logger_spec.rb
@@ -116,12 +116,14 @@ describe Sapience::Logger do
   describe "#log" do
     include_context "logs"
     let(:appender) { Sapience.add_appender(:stream, file_name: "log/test.log", formatter: :color) }
+    let(:ex) { StandardError.new("We failed") }
     subject(:logger) { described_class.new("Test", :info) }
 
     specify "handles standard error" do
       allow(described_class).to receive(:logger).and_return(appender)
-      allow(appender).to receive(:log).with(log).and_raise(StandardError, "We failed")
-      expect(appender).to receive(:error).with("Appender thread: Failed to log to appender: #{appender.inspect}", a_kind_of(StandardError))
+      allow(appender).to receive(:log).with(log).and_raise(ex)
+
+      expect($stderr).to receive(:write).with("Appender thread: Failed to log to appender: #{appender.inspect}\n #{ex.inspect}")
       subject.log(log, "whaatever", "sapience")
     end
 


### PR DESCRIPTION
Currently we are trying to log Sapience exception via our standard way
of logging, therefore can create a loop.