### PR TITLE
Immediate executor by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v2.2.2
+
+- Set immediate_executor by default to avoid Errno::EIO error for multithreaded processes. 
+  This could happen when orphaned process (whose parent has died) attempts to get stdio from parent process, 
+  or when stream is closed.
+
 ## v2.2.1
 
 - Log directly to STDOUT for internal errors

--- a/config/default.yml
+++ b/config/default.yml
@@ -3,7 +3,7 @@ default:
   filter_parameters:
     - password
     - password_confirmation
-  log_executor: single_thread_executor
+  log_executor: immediate_executor
   log_level: info
   appenders:
     - stream:
@@ -11,7 +11,6 @@ default:
         formatter: color
 
 test:
-  log_executor: immediate_executor
   log_level: warn
   appenders:
     - stream:
@@ -19,7 +18,6 @@ test:
         formatter: color
 
 development:
-  log_executor: single_thread_executor
   log_level: debug
   appenders:
     - stream:
@@ -27,7 +25,6 @@ development:
         formatter: color
 
 production:
-  log_executor: single_thread_executor
   log_level: warn
   appenders:
     - stream:

--- a/lib/sapience/version.rb
+++ b/lib/sapience/version.rb
@@ -1,3 +1,3 @@
 module Sapience
-  VERSION = "2.2.1"
+  VERSION = "2.2.2"
 end

--- a/spec/lib/sapience/config_loader_spec.rb
+++ b/spec/lib/sapience/config_loader_spec.rb
@@ -14,7 +14,7 @@ describe Sapience::ConfigLoader do
         it "uses the default configuration" do
           expect(load_from_file).to eq(
           "default"    => {
-            "log_executor" => "single_thread_executor",
+            "log_executor" => "immediate_executor",
             "filter_parameters" => %w(password password_confirmation),
             "log_level" => "info",
             "appenders" => [{
@@ -25,7 +25,6 @@ describe Sapience::ConfigLoader do
             }],
           },
           "development" => {
-            "log_executor" => "single_thread_executor",
             "log_level" => "debug",
             "appenders" => [{
               "stream" => {
@@ -35,7 +34,6 @@ describe Sapience::ConfigLoader do
             }],
           },
           "production"  => {
-            "log_executor" => "single_thread_executor",
             "log_level" => "warn",
             "appenders" => [{
               "stream" => {
@@ -45,7 +43,6 @@ describe Sapience::ConfigLoader do
             }],
           },
           "test"        => {
-            "log_executor" => "immediate_executor",
             "log_level" => "warn",
             "appenders" => [{
               "stream" => {
@@ -80,7 +77,7 @@ describe Sapience::ConfigLoader do
         it "uses the default configuration" do
           expect(load_from_file).to eq(
             "default" => {
-              "log_executor" => "single_thread_executor",
+              "log_executor" => "immediate_executor",
               "filter_parameters" => %w(password password_confirmation),
               "log_level" => "info",
               "appenders" => [
@@ -93,7 +90,6 @@ describe Sapience::ConfigLoader do
               ],
             },
             "development" => {
-              "log_executor" => "single_thread_executor",
               "log_level" => "debug",
               "appenders" => [
                 {
@@ -105,7 +101,6 @@ describe Sapience::ConfigLoader do
               ],
             },
             "production" => {
-              "log_executor" => "single_thread_executor",
               "log_level" => "warn",
               "appenders" => [
                 {
@@ -117,7 +112,6 @@ describe Sapience::ConfigLoader do
               ],
             },
             "test" => {
-              "log_executor" => "immediate_executor",
               "log_level" => "warn",
               "appenders" => [
                 {


### PR DESCRIPTION
Set immediate_executor by default to avoid Errno::EIO error for multithreaded processes. This could happen when orphaned process (whose parent has died) attempts to get stdio from parent process, or when stream is closed.