### PR TITLE
Remove ActiveRecord log level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v2.3.2
+
+- Changing the log level of ActiveRecord has the side effect of changing the
+  log level of Rails.logger. We don't want that therefore we remove the
+  assignment.
+
 ## v2.3.1
 
 - Add namespaced events

--- a/README.md
+++ b/README.md
@@ -104,7 +104,6 @@ Add a `config/sapience.yml` file to you appplication. Or if you, like us, have m
 default:
   app_name: My Application
   log_level: debug
-  log_level_active_record: info
   appenders:
     - stream:
         io: STDOUT
@@ -159,7 +158,6 @@ production:
 Sapience.configure(force: true) do |config|
   config.app_name = "My Application"
   config.default_level   = :info
-  config.log_level_active_record = :info
   config.backtrace_level = :error
   config.filter_parameters = %w(password password_confirmation)
   config.appenders       = [

--- a/lib/sapience/configuration.rb
+++ b/lib/sapience/configuration.rb
@@ -4,14 +4,13 @@ module Sapience
 
   # rubocop:disable ClassVars
   class Configuration
-    attr_reader :default_level, :log_level_active_record, :backtrace_level, :backtrace_level_index
+    attr_reader :default_level, :backtrace_level, :backtrace_level_index
     attr_writer :host
     attr_accessor :app_name, :ap_options, :appenders, :log_executor, :filter_parameters, :metrics, :error_handler
 
     SUPPORTED_EXECUTORS = %i(single_thread_executor immediate_executor).freeze
     DEFAULT = {
       log_level:               :info,
-      log_level_active_record: :info,
       host:              nil,
       ap_options:        { multiline: false },
       appenders:         [{ stream: { io: STDOUT, formatter: :color } }],
@@ -28,7 +27,6 @@ module Sapience
       @options[:log_executor] &&= @options[:log_executor].to_sym
       validate_log_executor!(@options[:log_executor])
       self.default_level           = @options[:log_level].to_sym
-      self.log_level_active_record = @options[:log_level_active_record].to_sym
       self.backtrace_level   = @options[:log_level].to_sym
       self.host              = @options[:host]
       self.app_name          = @options[:app_name]
@@ -45,13 +43,6 @@ module Sapience
       @default_level       = level
       # For performance reasons pre-calculate the level index
       @default_level_index = level_to_index(level)
-    end
-
-    # Sets the active record log level
-    def log_level_active_record=(level)
-      @log_level_active_record = level
-      # For performance reasons pre-calculate the level index
-      @log_level_active_record_index = level_to_index(level)
     end
 
     # Returns the symbolic level for the supplied level index

--- a/lib/sapience/rails/engine.rb
+++ b/lib/sapience/rails/engine.rb
@@ -72,12 +72,7 @@ module Sapience
         Bugsnag.configure { |config| config.logger = Sapience[Bugsnag] } if defined?(Bugsnag)
         Sapience::Extensions::ActionController::LogSubscriber.attach_to :action_controller
         # Sapience::Extensions::ActiveSupport::MailerLogSubscriber.attach_to :action_mailer
-        if defined?(ActiveRecord)
-          Sapience::Extensions::ActiveRecord::Notifications.use
-          ActiveRecord::Base.logger.level =
-              Sapience.config.log_level_active_record if defined?(ActiveRecord::Base.logger.level)
-        end
-
+        Sapience::Extensions::ActiveRecord::Notifications.use if defined?(ActiveRecord)
         Sapience::Extensions::ActionView::LogSubscriber.attach_to :action_view
         # Sapience::Extensions::ActiveJob::LogSubscriber.attach_to :active_job
         Sapience::Extensions::ActionController::Notifications.use

--- a/lib/sapience/version.rb
+++ b/lib/sapience/version.rb
@@ -1,3 +1,3 @@
 module Sapience
-  VERSION = "2.3.1"
+  VERSION = "2.3.2"
 end

--- a/spec/lib/sapience/configuration_spec.rb
+++ b/spec/lib/sapience/configuration_spec.rb
@@ -9,17 +9,6 @@ describe Sapience::Configuration do
     end
   end
 
-  describe "#log_level_active_record" do
-    it "sets the default level to :info" do
-      expect(Sapience.config.log_level_active_record).to eq(:info)
-    end
-
-    it "can override the default level" do
-      Sapience.config.log_level_active_record = :debug
-      expect(Sapience.config.log_level_active_record).to eq(:debug)
-    end
-  end
-
   describe "#level_to_index" do
     def level_to_index
       subject.level_to_index(level)


### PR DESCRIPTION
Changing the log level of ActiveRecord has the side effect of changing
the log level of Rails.logger. We don't want that therefore we remove
the assignment.