### PR TITLE
Metrics shortcuts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## v2.4.0
+
+- Add shortcut metrics
+    - `Sapience.metrics.success(module_name<string>, action<string>, opts<hash>)`
+    - `Sapience.metrics.error(module_name<string>, action<string>, opts<hash>)`
+    - `Sapience.metrics.exception(module_name<string>, action<string>, opts<hash>)`
+
 ## v2.3.5
 
 - Set Sapience.config.app_name when APP_NAME environment variable is set 

--- a/lib/sapience/error_handler/sentry.rb
+++ b/lib/sapience/error_handler/sentry.rb
@@ -23,8 +23,9 @@ module Sapience
       #   dsn: [String]
       #     Url to configure Sentry-Raven.
       #     Default: nil
-      def initialize(options = {})
-        fail ArgumentError, "Options should be a Hash" unless options.is_a?(Hash)
+      def initialize(opts = {})
+        fail ArgumentError, "Options should be a Hash" unless opts.is_a?(Hash)
+        options = opts.dup
 
         options[:level] ||= :error
         @sentry_logger_level = options[:level]

--- a/lib/sapience/metrics/datadog.rb
+++ b/lib/sapience/metrics/datadog.rb
@@ -135,6 +135,18 @@ module Sapience
         provider.event(title, text, opts)
       end
 
+      def success(module_name, action, opts = {})
+        increment("success", add_tags(module_name, action, opts))
+      end
+
+      def error(module_name, action, opts = {})
+        increment("error", add_tags(module_name, action, opts))
+      end
+
+      def exception(module_name, action, opts = {})
+        increment("exception", add_tags(module_name, action, opts))
+      end
+
       def namespace
         ns = Sapience.namify(Sapience.app_name)
         ns << ".#{Sapience.namify(Sapience.environment)}" if Sapience.environment
@@ -146,6 +158,23 @@ module Sapience
           namespace: namespace,
           tags: @tags,
         }
+      end
+
+      private
+
+      def add_tags(module_name, action, opts)
+        tags = opts.fetch(:tags, [])
+        clean_up_tags(tags, :module, module_name)
+        clean_up_tags(tags, :action, action)
+        tags << "module:#{module_name}" << "action:#{action}"
+        opts[:tags] = tags
+        opts
+      end
+
+      def clean_up_tags(tags, key, value)
+        old_tags = tags.dup
+        tags.delete_if { |a| a =~ /^#{key}:/ }
+        ::Sapience.logger.warn("WARNING: tag '#{key}' already exist, overwritten with #{value}") if tags != old_tags
       end
     end
   end

--- a/lib/sapience/version.rb
+++ b/lib/sapience/version.rb
@@ -1,3 +1,3 @@
 module Sapience
-  VERSION = "2.3.5"
+  VERSION = "2.4.0"
 end


### PR DESCRIPTION
https://reevoo.atlassian.net/browse/TECH-164
Add shortcut metrics
- `Sapience.metrics.success(module_name<string>, action<string>, opts<hash>)`
- `Sapience.metrics.error(module_name<string>, action<string>, opts<hash>)`
- `Sapience.metrics.exception(module_name<string>, action<string>, opts<hash>)`