### PR TITLE
Fix compatibility issue with concurrent-ruby logger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
+## v2.5.4
+
+- Add compatibility fix for concurrent-ruby library logger which expect `call` method to be defined
+
 ## v2.5.3
 
-- Fix issues after applying fronzen_string_literal = true. Make it compatible to Ruby 2.1 
+- Fix issues after applying fronzen_string_literal = true. Make it compatible to Ruby 2.1
 
 ## v2.5.2
 
@@ -21,7 +25,7 @@
 
 ## v2.3.5
 
-- Set Sapience.config.app_name when APP_NAME environment variable is set 
+- Set Sapience.config.app_name when APP_NAME environment variable is set
 
 ## v2.3.3
 
@@ -39,8 +43,8 @@
 
 ## v2.2.3
 
-- Set immediate_executor by default to avoid Errno::EIO error for multithreaded processes. 
-  This could happen when orphaned process (whose parent has died) attempts to get stdio from parent process, 
+- Set immediate_executor by default to avoid Errno::EIO error for multithreaded processes.
+  This could happen when orphaned process (whose parent has died) attempts to get stdio from parent process,
   or when stream is closed.
 
 ## v2.2.1
@@ -107,7 +111,7 @@
 
 ## v1.0.10
 
-- Automatically add default `datadog` appender when calling `Sapience.metrics` 
+- Automatically add default `datadog` appender when calling `Sapience.metrics`
 
 ## v1.0.9
 

--- a/lib/sapience/loggers/concurrent.rb
+++ b/lib/sapience/loggers/concurrent.rb
@@ -1,0 +1,17 @@
+# Sapience::Loggers::Concurrent is a class wrapping all methods necessary for integration with concurrent-ruby gem .
+module Sapience
+  module Loggers
+    class Concurrent < Sapience::Logger
+
+      def initialize(level = nil, filter = nil)
+        super("Concurrent", level, filter)
+      end
+
+      # *call* method is expected to be defined for all Concurrent.global_logger instances
+      # see https://github.com/ruby-concurrency/concurrent-ruby/blob/master/lib/concurrent/concern/logging.rb#L25
+      def call(level, progname, message, &block)
+        log(level, message, progname, &block)
+      end
+    end
+  end
+end

--- a/lib/sapience/rails/engine.rb
+++ b/lib/sapience/rails/engine.rb
@@ -13,6 +13,7 @@ require "sapience/extensions/active_job/notifications" if defined?(ActiveJob)
 require "sapience/extensions/rails/rack/logger"
 require "sapience/extensions/rails/rack/logger_info_as_debug"
 require "sapience/extensions/action_view/log_subscriber"
+require "sapience/loggers/concurrent"
 
 module Sapience
   module Rails
@@ -58,7 +59,7 @@ module Sapience
         Bugsnag.configure { |config| config.logger = Sapience[Bugsnag] } if defined?(Bugsnag)
 
         # Set the logger for concurrent-ruby
-        Concurrent.global_logger = Sapience[Concurrent] if defined?(Concurrent)
+        Concurrent.global_logger = Sapience::Loggers::Concurrent.new if defined?(Concurrent)
       end
 
       # Before any initializers run, but after the gems have been loaded

--- a/lib/sapience/version.rb
+++ b/lib/sapience/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module Sapience
-  VERSION = "2.5.3"
+  VERSION = "2.5.4"
 end

--- a/spec/lib/sapience/loggers/concurrent_spec.rb
+++ b/spec/lib/sapience/loggers/concurrent_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+require "spec_helper"
+require "sapience/loggers/concurrent"
+
+describe Sapience::Loggers::Concurrent do
+  describe ".new" do
+    subject { described_class.new }
+
+    its(:name) { is_expected.to eq("Concurrent") }
+
+    context ".call" do
+      let(:level) { 1 }
+      let(:progname) { "progname" }
+      let(:message) { "message" }
+
+      it "calls log method with parameters in specific order" do
+        expect(subject).to receive(:log).with(level, message, progname)
+        subject.call(1, progname, message)
+      end
+    end
+  end
+end


### PR DESCRIPTION
- concurrent-ruby logger expect `call` method to be defined
- see https://github.com/ruby-concurrency/concurrent-ruby/blob/master/lib/concurrent/concern/logging.rb#L25