### PR TITLE
Fix sentry logging when payload is nil

### DIFF
--- a/lib/sapience/error_handler/sentry.rb
+++ b/lib/sapience/error_handler/sentry.rb
@@ -107,7 +107,11 @@ module Sapience
         return false unless valid?
         configure_sentry
 
-        options = payload[:extra] ? payload : { extra: payload }
+        options = if payload.present?
+                    payload[:extra] ? payload : { extra: payload }
+                  else
+                    {}
+                  end
 
         Raven.capture_type(data, options) if @configured
         true

--- a/lib/sapience/version.rb
+++ b/lib/sapience/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module Sapience
-  VERSION = "2.6.0"
+  VERSION = "2.6.1"
 end

--- a/spec/lib/sapience/error_handler/sentry_spec.rb
+++ b/spec/lib/sapience/error_handler/sentry_spec.rb
@@ -212,5 +212,17 @@ describe Sapience::ErrorHandler::Sentry do
         end
       end
     end
+
+    context "when param 'options' is nil" do
+      let(:options) { nil }
+
+      it "passes options to Raven under key 'extra'" do
+        expect(Raven).to receive(:capture_type).with(exception, {})
+
+        subject.capture(options) do
+          fail exception
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
- there are situations where payload is not passed to capture function. In such cases code failed and exception was never passed to sentry.
- this commit aim to fix such a situations and pass exception to sentry without any additional details