### PR TITLE
Silence rack logger for rails 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,8 @@ services:
   - docker
 
 before_install:
-  - gem install bundler
+  - gem uninstall -v '>= 2' -i $(rvm gemdir)@global -ax bundler || true
+  - gem install bundler -v '< 2'
 
 install: bundle install --jobs 8 --retry 5
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## v2.8.0
+- Silence rails rack logger for rails 3 by setting `silent_rack: true` in sapience.yml
+
 ## v2.7.0
 - Add ability to stop generating metrics for ActiveRecord::Notification with config option `silent_active_record`
 

--- a/README.md
+++ b/README.md
@@ -166,6 +166,7 @@ staging:
 production:
   log_level: info
   silent_rails: true # make rails logging less noisy
+  silent_rack: true # stop rack from logging "Request Started..." messages
   error_handler:
     sentry:
       dsn: <%= ENV['SENTRY_DSN'] %>
@@ -186,6 +187,7 @@ Sapience.configure(force: true) do |config|
   config.default_level   = :info
   config.backtrace_level = :error
   config.silent_rails = true # make rails logging less noisy
+  config.silent_rack = true # silence rack logging
   config.filter_parameters = %w(password password_confirmation)
   config.appenders       = [
       { stream: { io: STDOUT, formatter: :color } },

--- a/lib/sapience/configuration.rb
+++ b/lib/sapience/configuration.rb
@@ -8,7 +8,7 @@ module Sapience
     attr_reader :default_level, :backtrace_level, :backtrace_level_index
     attr_writer :host
     attr_accessor :app_name, :ap_options, :appenders, :log_executor, :filter_parameters,
-      :metrics, :error_handler, :silent_active_record, :silent_rails
+      :metrics, :error_handler, :silent_active_record, :silent_rails, :silent_rack
 
     SUPPORTED_EXECUTORS = %i(single_thread_executor immediate_executor).freeze
     DEFAULT = {
@@ -22,6 +22,7 @@ module Sapience
       filter_parameters: %w(password password_confirmation),
       silent_active_record: false,
       silent_rails:      false,
+      silent_rack:       false,
     }.freeze
 
     # Initial default Level for all new instances of Sapience::Logger
@@ -30,7 +31,7 @@ module Sapience
       @options = DEFAULT.merge(options.dup.deep_symbolize_keyz!)
       @options[:log_executor] &&= @options[:log_executor].to_sym
       validate_log_executor!(@options[:log_executor])
-      self.default_level = @options[:log_level].to_sym
+      self.default_level     = @options[:log_level].to_sym
       self.backtrace_level   = @options[:log_level].to_sym
       self.host              = @options[:host]
       self.app_name          = @options[:app_name]
@@ -41,7 +42,8 @@ module Sapience
       self.metrics           = @options[:metrics]
       self.error_handler     = @options[:error_handler]
       self.silent_active_record = @options[:silent_active_record]
-      self.silent_rails = @options[:silent_rails]
+      self.silent_rails      = @options[:silent_rails]
+      self.silent_rack       = @options[:silent_rack]
     end
 
     # Sets the global default log level

--- a/lib/sapience/extensions/rails/rack/logger_info_as_debug.rb
+++ b/lib/sapience/extensions/rails/rack/logger_info_as_debug.rb
@@ -1,6 +1,19 @@
 # frozen_string_literal: true
-# Drop rack Started message to debug level message
+require "rails/rack/logger"
+
+# For rails > 3, drop rack Started message to debug level message
+# For rails == 3, patch the logger to remove the log lines
+# that say: 'Started GET / for 192.168.2.1...'
 class Rails::Rack::Logger # rubocop:disable ClassAndModuleChildren
+
+  if Rails::VERSION::MAJOR == 3 && ::Sapience.config.silent_rack
+    def call_app(*args)
+      env = args.last
+      @app.call(env)
+    ensure
+      ActiveSupport::LogSubscriber.flush_all!
+    end
+  end
 
   private
 

--- a/lib/sapience/version.rb
+++ b/lib/sapience/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module Sapience
-  VERSION = "2.7.0"
+  VERSION = "2.8"
 end


### PR DESCRIPTION
For rails 3, patch the logger to remove the log lines that say: 'Started GET / for 192.168.2.1...'