### PR TITLE
Config option for ActionController metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## v2.11
+- Add config option to enable/disable metrics from ActionController
+
 ## v2.10
 - Fix spec for Ruby 2.4.1
 - Bump version to 2.10 in order to properly highlight more significant change

--- a/README.md
+++ b/README.md
@@ -22,6 +22,15 @@ Add the gem:
 gem "sapience", require: "sapience/rails"
 ```
 
+The rails integration has the following configuration options:
+
+| Option                | Description | Values    | Default |
+| --------------------- | ---------- | ------     | ----- |
+| silent_rails          | less noisy rails logs       | `boolean`  | `true` |
+| silent_rack           | suppress "Request Started..." log message from rack | `boolean`  | `true` |
+| silent_active_record  | emit metrics from ActiveRecord    | `boolean`  | `true` |
+| rails_ac_metrics      | emit metrics from ActionController | `boolean`  | `true` |
+
 ### Sinatra
 Add the gem:
 
@@ -156,6 +165,10 @@ Or if you, like us, have many projects that use the same configuration you can c
 default:
   app_name: My Application
   log_level: debug
+  silent_active_record: true
+  silent_rails: true
+  silent_rack: true
+  rails_ac_metrics: true
   appenders:
     - stream:
         io: STDOUT

--- a/lib/sapience/configuration.rb
+++ b/lib/sapience/configuration.rb
@@ -8,7 +8,8 @@ module Sapience
     attr_reader :default_level, :backtrace_level, :backtrace_level_index
     attr_writer :host
     attr_accessor :app_name, :ap_options, :appenders, :log_executor, :filter_parameters,
-      :metrics, :error_handler, :silent_active_record, :silent_rails, :silent_rack
+      :metrics, :error_handler, :silent_active_record, :silent_rails, :silent_rack,
+      :rails_ac_metrics
 
     SUPPORTED_EXECUTORS = %i(single_thread_executor immediate_executor).freeze
     DEFAULT = {
@@ -23,6 +24,7 @@ module Sapience
       silent_active_record: false,
       silent_rails:      false,
       silent_rack:       false,
+      rails_ac_metrics:  true,
     }.freeze
 
     # Initial default Level for all new instances of Sapience::Logger
@@ -44,6 +46,7 @@ module Sapience
       self.silent_active_record = @options[:silent_active_record]
       self.silent_rails      = @options[:silent_rails]
       self.silent_rack       = @options[:silent_rack]
+      self.rails_ac_metrics = @options[:rails_ac_metrics]
     end
 
     # Sets the global default log level

--- a/lib/sapience/rails/engine.rb
+++ b/lib/sapience/rails/engine.rb
@@ -83,7 +83,7 @@ module Sapience
         end
         Sapience::Extensions::ActionView::LogSubscriber.attach_to :action_view
         # Sapience::Extensions::ActiveJob::LogSubscriber.attach_to :active_job
-        Sapience::Extensions::ActionController::Notifications.use
+        Sapience::Extensions::ActionController::Notifications.use if Sapience.config.rails_ac_metrics
         Sapience::Extensions::ActiveJob::Notifications.use if defined?(ActiveJob)
       end
     end

--- a/lib/sapience/version.rb
+++ b/lib/sapience/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module Sapience
-  VERSION = "2.10"
+  VERSION = "2.11"
 end

--- a/sapience.gemspec
+++ b/sapience.gemspec
@@ -37,7 +37,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "memory_profiler"
   spec.add_development_dependency "pry-nav"
   spec.add_development_dependency "rails", "~> 5.0.0.1"
-  spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "rake"
   spec.add_development_dependency "reevoocop"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "rspec-its"


### PR DESCRIPTION
By default, extension sapience/rails collects ActionController metrics
by registering a listener to ActiveSupport::Notifications.  These
metrics will be emited to a metrics provider, if one has been
configured. This is useful when we don't use a dedicated tracing library
like datadog, newrelic, skylight etc.

This commit introduces a config option `rails_ac_metrics` that allows us
to control whether we want this functionallity enabled or not.