### PR TITLE
feature: config option for grape  metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## v2.13
+- Add config option to enable/disable metrics from grape
+
 ## v2.12
 - feature: 'log hooks', a mechanism for modifying the log event just before it is added to the appender
 

--- a/README.md
+++ b/README.md
@@ -128,6 +128,13 @@ API.logger = Sapience.logger
 **Note**: If you're using the rackup command to run your server in development, pass the -q flag to silence the default
 rack logger so you don't get double logging.
 
+
+The grape integration has the following configuration options:
+
+| Option                | Description | Values    | Default |
+| --------------------- | ---------- | ------     | ----- |
+| grape_metrics         | emit metrics from grape | `boolean`  | `true` |
+
 ### Standalone
 Add the gem:
 

--- a/lib/sapience/configuration.rb
+++ b/lib/sapience/configuration.rb
@@ -9,7 +9,7 @@ module Sapience
     attr_writer :host
     attr_accessor :app_name, :ap_options, :appenders, :log_executor, :filter_parameters,
       :metrics, :error_handler, :silent_active_record, :silent_rails, :silent_rack,
-      :rails_ac_metrics
+      :rails_ac_metrics, :grape_metrics
 
     SUPPORTED_EXECUTORS = %i(single_thread_executor immediate_executor).freeze
     DEFAULT = {
@@ -25,6 +25,7 @@ module Sapience
       silent_rails:      false,
       silent_rack:       false,
       rails_ac_metrics:  true,
+      grape_metrics:     true,
     }.freeze
 
     # Initial default Level for all new instances of Sapience::Logger
@@ -46,7 +47,8 @@ module Sapience
       self.silent_active_record = @options[:silent_active_record]
       self.silent_rails      = @options[:silent_rails]
       self.silent_rack       = @options[:silent_rack]
-      self.rails_ac_metrics = @options[:rails_ac_metrics]
+      self.rails_ac_metrics  = @options[:rails_ac_metrics]
+      self.grape_metrics     = @options[:grape_metrics]
     end
 
     # Sets the global default log level

--- a/lib/sapience/grape.rb
+++ b/lib/sapience/grape.rb
@@ -19,6 +19,6 @@ module Sapience
     end
     Sapience.configure
     ::Grape::API.send(:include, Sapience::Loggable)
-    Sapience::Extensions::Grape::Notifications.use
+    Sapience::Extensions::Grape::Notifications.use if Sapience.config.grape_metrics
   end
 end

--- a/lib/sapience/version.rb
+++ b/lib/sapience/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module Sapience
-  VERSION = "2.12"
+  VERSION = "2.13"
 end


### PR DESCRIPTION
By default, extension sapience/grape collects metrics from grape endpoints and
emits them, if a metrics provider has been configured. This is useful when we
don't use a dedicated tracing library like datadog, newrelic, skylight etc.

This commit introduces a new config option, *grape_metrics*, that allows us to
control whether we want to emit metrics or not.