### PR TITLE
Don't assign Sequel logger unless method available

### DIFF
--- a/lib/sapience/rails/engine.rb
+++ b/lib/sapience/rails/engine.rb
@@ -42,11 +42,13 @@ module Sapience
         # Replace the Sidekiq logger
         Sidekiq::Logging.logger     = Sapience[Sidekiq] if defined?(Sidekiq)
 
-        # Replace the Sequel logger
-        Sequel::Database.logger     = Sapience[Sequel] if defined?(Sequel::Database)
-
         # Replace the Sidetiq logger
         Sidetiq.logger              = Sapience[Sidetiq] if defined?(Sidetiq)
+
+        # Replace the Sequel logger
+        if defined?(Sequel::Database) && Sequel::Database.respond_to?(:logger=)
+          Sequel::Database.logger = Sapience[Sequel]
+        end
 
         # Replace the Raven logger
         # Raven::Configuration.logger = Sapience[Raven::Configuration] if defined?(Raven::Configuration)

--- a/lib/sapience/version.rb
+++ b/lib/sapience/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module Sapience
-  VERSION = "2.13"
+  VERSION = "2.14"
 end


### PR DESCRIPTION
It doesn't work with ROM wrapped Sequel we use Smart. On top of it we have multiple dbs, therefore this automatic inicialization doesn't make sense.