### PR TITLE
A Formatter can now be configured to exclude selected log fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v2.15
+- The Formatter can now be configured to exclude selected log fields.
+  Currently only the Json formatter implements this.
+
 ## v2.13
 - Add config option to enable/disable metrics from grape
 

--- a/docs/appenders/formatters.md
+++ b/docs/appenders/formatters.md
@@ -13,6 +13,58 @@ Formatters can be specified by using the key `formatter: :camelized_formatter_na
 ### JSON
 
 `formatter: :json` - logs are saved as a single line json. Useful for production like environments.
+The json formatter can be configured to filter out select log fields. The following configuration demonstrates this:
+
+```yaml
+json_formatter: &json_slim
+  json:
+    exclude_fields:
+      - "name"
+      - "request_id"
+      - "thread"
+      - "pid"
+      - "level_index"
+      - "host"
+      - "app_name"
+      - "request_id"
+      - "action"
+      - "controller"
+      - "route"
+      - "file"
+      - "line"
+      - "format"
+      - "tags"
+
+ci:
+  log_level: warn
+  appenders:
+    - stream:
+        io: STDOUT
+        formatter: color
+
+production:
+  log_level: info
+  appenders:
+    - stream:
+        io: STDOUT
+        formatter:
+          <<: *json_slim
+
+staging:
+  log_level: info
+  appenders:
+    - stream:
+        io: STDOUT
+        formatter:
+          <<: *json_slim
+
+development:
+  log_level: debug
+  appenders:
+    - stream:
+        io: STDOUT
+        formatter: json
+```
 
 ### RAW
 

--- a/lib/sapience/config_loader.rb
+++ b/lib/sapience/config_loader.rb
@@ -70,12 +70,13 @@ module Sapience
         if YAML.respond_to?(:safe_load) # Ruby 2.1+
           if defined?(SafeYAML) && SafeYAML.respond_to?(:load)
             SafeYAML.load(yaml_code, filename,
-              whitelisted_tags: %w(!ruby/regexp))
+              whitelisted_tags: %w(!ruby/regexp),
+              aliases: true)
           else
-            YAML.safe_load(yaml_code, [Regexp], [], false, filename)
+            YAML.safe_load(yaml_code, [Regexp], [], true, filename)
           end
         else
-          YAML.safe_load(yaml_code, filename)
+          YAML.safe_load(yaml_code, filename, aliases: true)
         end
       end
     end

--- a/lib/sapience/formatters/base.rb
+++ b/lib/sapience/formatters/base.rb
@@ -2,7 +2,7 @@
 module Sapience
   module Formatters
     class Base
-      attr_accessor :time_format, :precision, :log_host, :log_application
+      attr_accessor :time_format, :default_time_format, :precision, :log_host, :log_application, :exclude_fields
 
       # Parameters
       #   time_format: [String|Symbol|nil]
@@ -11,13 +11,9 @@ module Sapience
       #     nil:      Returns Empty string for time ( no time is output ).
       #     Default: '%Y-%m-%d %H:%M:%S.%6N'
       def initialize(options = {})
-        options          = options.dup
-        @precision       = 6
-        default_format   = "%Y-%m-%d %H:%M:%S.%#{precision}N"
-        @time_format     = options.key?(:time_format) ? options.delete(:time_format) : default_format
-        @log_host        = options.key?(:log_host) ? options.delete(:log_host) : true
-        @log_application = options.key?(:log_application) ? options.delete(:log_application) : true
-        fail(ArgumentError, "Unknown options: #{options.inspect}") unless options.empty?
+        @precision           = 6
+        @default_time_format = "%Y-%m-%d %H:%M:%S.%#{precision}N"
+        parse_options(options.dup)
       end
 
       # Return the Time as a formatted string
@@ -32,6 +28,15 @@ module Sapience
         end
       end
 
+      private
+
+      def parse_options(options)
+        @time_format     = options.key?(:time_format) ? options.delete(:time_format) : default_time_format
+        @log_host        = options.key?(:log_host) ? options.delete(:log_host) : true
+        @log_application = options.key?(:log_application) ? options.delete(:log_application) : true
+        @exclude_fields  = options.key?(:exclude_fields) ? options.delete(:exclude_fields).map(&:to_sym) : {}
+        fail(ArgumentError, "Unknown options: #{options.inspect}") unless options.empty?
+      end
     end
   end
 end

--- a/lib/sapience/formatters/json.rb
+++ b/lib/sapience/formatters/json.rb
@@ -13,9 +13,25 @@ module Sapience
       # Returns log messages in JSON format
       def call(log, logger)
         h = super(log, logger)
-        h.delete(:time)
-        h[:timestamp] = format_time(log.time)
-        h.to_json
+        prepare(h, log).to_json
+      end
+
+      private
+
+      def prepare(log_hash, log)
+        set_timestamp(log_hash, log)
+        remove_fields(log_hash)
+        log_hash
+      end
+
+      def set_timestamp(log_hash, log)
+        log_hash.delete(:time)
+        log_hash[:timestamp] = format_time(log.time)
+        log_hash
+      end
+
+      def remove_fields(log_hash)
+        log_hash.delete_if { |k, _v| exclude_fields.include?(k.to_sym) } if exclude_fields.any?
       end
     end
   end

--- a/lib/sapience/version.rb
+++ b/lib/sapience/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module Sapience
-  VERSION = "2.14"
+  VERSION = "2.15"
 end

--- a/spec/lib/sapience/formatters/json_spec.rb
+++ b/spec/lib/sapience/formatters/json_spec.rb
@@ -19,29 +19,55 @@ describe Sapience::Formatters::Json do
 
     specify do
       is_expected.to match(
-        app_name: Sapience.app_name,
-        duration: "9.999s",
-        duration_ms: duration,
-        exception: a_hash_including(
-          name: exception.class.name,
-          message: exception_message_two,
-          stack_trace: a_kind_of(Array),
-        ),
-        file: a_string_ending_with("/sapience.rb"),
-        host: a_kind_of(String),
-        level: "info",
-        level_index: 2,
-        line: a_kind_of(Integer),
-        message: message,
-        metric: metric,
-        payload: "HEY HO",
-        name: name,
-        pid: a_kind_of(Integer),
-        tags: tags,
-        thread: thread_name,
-        timestamp: a_kind_of(String),
-        environment: Sapience.environment,
-    )
+                       app_name: Sapience.app_name,
+                       duration: "9.999s",
+                       duration_ms: duration,
+                       exception: a_hash_including(
+                         name: exception.class.name,
+                         message: exception_message_two,
+                         stack_trace: a_kind_of(Array),
+                       ),
+                       file: a_string_ending_with("/sapience.rb"),
+                       host: a_kind_of(String),
+                       level: "info",
+                       level_index: 2,
+                       line: a_kind_of(Integer),
+                       message: message,
+                       metric: metric,
+                       payload: "HEY HO",
+                       name: name,
+                       pid: a_kind_of(Integer),
+                       tags: tags,
+                       thread: thread_name,
+                       timestamp: a_kind_of(String),
+                       environment: Sapience.environment,
+                     )
+    end
+
+    context "with option 'excluded_fields'" do
+      let(:formatter) do
+        described_class.new(
+                exclude_fields: %i[name level_index line pid thread file host app_name duration],
+      )
+      end
+
+      specify do
+        is_expected.to match(
+                         duration_ms: duration,
+                         exception: a_hash_including(
+                           name: exception.class.name,
+                           message: exception_message_two,
+                           stack_trace: a_kind_of(Array),
+                           ),
+                         level: "info",
+                         message: message,
+                         metric: metric,
+                         payload: "HEY HO",
+                         tags: tags,
+                         timestamp: a_kind_of(String),
+                         environment: Sapience.environment,
+                         )
+      end
     end
   end
 end


### PR DESCRIPTION
  In case we want to reduce the volume of generated log data we can now
  configure the Formatter to exclude some fields from the output.
  This is currently implemented only by the Json formatter.
